### PR TITLE
[feat/6]

### DIFF
--- a/src/main/java/manage/store/service/money/sales/SalesSummaryServiceImpl.java
+++ b/src/main/java/manage/store/service/money/sales/SalesSummaryServiceImpl.java
@@ -106,8 +106,14 @@ public class SalesSummaryServiceImpl implements SalesSummaryService {
 
             // 주간 평균 일 매출 계산
             // 1) 월요일부터 현재까지 몇 일 지났는지 일 수 계산
+            LocalDate now = LocalDate.now();
             DayOfWeek curDayOfWeek = registDate.getDayOfWeek();
             int curDayPassedAtWeekCnt = curDayOfWeek.getValue();
+            // 특정 매출 주 데이터에서 오늘 날짜가 아직 일요일까지 완성되지 않았을 경우 오늘 날짜에 대한 지난 일수를 사용
+            // (매출이 발생한 날짜에 대한 집계를 하기 위함)
+            if(DateUtils.isOnSameWeek(now, registDate) && registDate.isAfter(now)) {
+                curDayPassedAtWeekCnt = now.getDayOfWeek().getValue();
+            }
 
             // 2) 주간 총 매출 / 매출이 발생한 날짜 수를 통해 주간 평균 일 매출 계산
             Money weeklyAvgSales = new Money(curWeekSalesTotal.value() / curDayPassedAtWeekCnt);
@@ -117,6 +123,13 @@ public class SalesSummaryServiceImpl implements SalesSummaryService {
 
             // 2) (주간 총 매출 / 날짜 수) * 7일을 통해 주간 예측 매출 계산
             Money expectedTotalSales = new Money(weeklyAvgSales.value() * 7);
+
+            // 현재 계산중인 날짜가 일요일이거나 마지막 날이고 오늘 이전(이하)의 날이면 실제 주간 총 매출을 사용
+            // 아직 오늘이 일주일이 채워지기 전이라면 예측 데이터를 써야하고, 그 외 경우에는 모든 실제 매출 데이터를 사용
+            if(!DateUtils.isOnSameWeek(now, registDate) &&
+                    (curDayOfWeek == DayOfWeek.SUNDAY || registDate.getDayOfMonth() == registDate.lengthOfMonth())) {
+                expectedTotalSales = new Money(curWeekSalesTotal.value());
+            }
 
             // 주간 통계 업데이트
             int idx = weekNumber.value() - 1;

--- a/src/main/java/manage/store/utils/DateUtils.java
+++ b/src/main/java/manage/store/utils/DateUtils.java
@@ -7,6 +7,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.time.format.DateTimeParseException;
+import java.time.temporal.WeekFields;
 
 public class DateUtils {
 
@@ -42,6 +43,24 @@ public class DateUtils {
         }catch (DateTimeParseException e) {
             throw new InvalidParameterException("Invalid date format. Please use 'yyyy-MM-dd'. parameter: " + date);
         }
+    }
+
+    /**
+     * 동일한 주에 포함되는 여부 반환
+     * @param date1 날짜1
+     * @param date2 날짜2
+     * @return 동일년도의 동일주에 포함되면 true, 그 외 false
+     */
+    public static boolean isOnSameWeek(LocalDate date1, LocalDate date2) {
+        WeekFields weekFields = WeekFields.ISO;
+
+        int year1 = date1.get(weekFields.weekBasedYear());
+        int week1 = date1.get(weekFields.weekOfYear());
+
+        int year2 = date2.get(weekFields.weekBasedYear());
+        int week2 = date2.get(weekFields.weekOfYear());
+
+        return (year1 == year2) && (week1 == week2);
     }
 
     /**

--- a/src/test/java/manage/store/service/money/StoreSalesServiceImplTest.java
+++ b/src/test/java/manage/store/service/money/StoreSalesServiceImplTest.java
@@ -53,19 +53,19 @@ public class StoreSalesServiceImplTest {
         final int year = MonthlySalesUtils.YEAR_MONTH.getYear(), month = MonthlySalesUtils.YEAR_MONTH.getMonth();
         final GetMonthSalesRequest param = new GetMonthSalesRequest(branchCd, year, month);
 
-        final List<StoreSales> sampleStoreSales = MonthlySalesUtils.STORE_SALES_2023_05;
+        final List<StoreSales> sampleStoreSales = MonthlySalesUtils.STORE_SALES_2023_05();
         given(salesRepository.selectSalesByMonth(branchCd, year, month)).willReturn(sampleStoreSales);
 
-        final List<SalesDailySummary> salesDailySummary = MonthlySalesUtils.EXPECTED_DAILY_SUMMARY;
-        final List<SalesWeeklySummary> salesWeeklySummary = MonthlySalesUtils.EXPECTED_WEEKLY_SUMMARY;
+        final List<SalesDailySummary> salesDailySummary = MonthlySalesUtils.EXPECTED_DAILY_SUMMARY();
+        final List<SalesWeeklySummary> salesWeeklySummary = MonthlySalesUtils.EXPECTED_WEEKLY_SUMMARY();
         final GetMonthlySalesSummaryRslt summaryRslt = new GetMonthlySalesSummaryRslt(
                 branchCd,
                 new YearMonth(year, month),
                 salesDailySummary,
                 salesWeeklySummary,
-                MonthlySalesUtils.MONTH_TOTAL_CARD,
-                MonthlySalesUtils.MONTH_TOTAL_CASH,
-                MonthlySalesUtils.MONTH_TOTAL_CARD.add(MonthlySalesUtils.MONTH_TOTAL_CASH)
+                MonthlySalesUtils.MONTH_TOTAL_CARD(),
+                MonthlySalesUtils.MONTH_TOTAL_CASH(),
+                MonthlySalesUtils.MONTH_TOTAL_CARD().add(MonthlySalesUtils.MONTH_TOTAL_CASH())
         );
         given(salesSummaryService.getMonthSalesSummary(any())).willReturn(summaryRslt);
 
@@ -86,7 +86,7 @@ public class StoreSalesServiceImplTest {
         for (int i = 0; i < result.getDailySales().size(); i++) {
             GetMonthSalesResponse.DailySales actual = result.getDailySales().get(i);
             SalesDailySummary expectedSummary = salesDailySummary.get(i);
-            BasicDailySales expectedBasicSales = MonthlySalesUtils.BASIC_DAILY_SALES_2023_05.get(i);
+            BasicDailySales expectedBasicSales = MonthlySalesUtils.BASIC_DAILY_SALES_2023_05().get(i);
 
             Assertions.assertThat(actual.getBranchCd()).isEqualTo(expectedBasicSales.getBranchCd());
             Assertions.assertThat(actual.getRegistDate()).isEqualTo(expectedBasicSales.getRegistDate());
@@ -116,9 +116,9 @@ public class StoreSalesServiceImplTest {
         }
 
         // 월 총
-        Assertions.assertThat(result.getMonthTotalCard()).isEqualTo(MonthlySalesUtils.MONTH_TOTAL_CARD);
-        Assertions.assertThat(result.getMonthTotalCash()).isEqualTo(MonthlySalesUtils.MONTH_TOTAL_CASH);
-        Assertions.assertThat(result.getMonthTotalSales()).isEqualTo(MonthlySalesUtils.MONTH_TOTAL_CARD.add(MonthlySalesUtils.MONTH_TOTAL_CASH));
+        Assertions.assertThat(result.getMonthTotalCard()).isEqualTo(MonthlySalesUtils.MONTH_TOTAL_CARD());
+        Assertions.assertThat(result.getMonthTotalCash()).isEqualTo(MonthlySalesUtils.MONTH_TOTAL_CASH());
+        Assertions.assertThat(result.getMonthTotalSales()).isEqualTo(MonthlySalesUtils.MONTH_TOTAL_CARD().add(MonthlySalesUtils.MONTH_TOTAL_CASH()));
 
     }
 

--- a/src/test/java/manage/store/service/money/sales/SalesSummaryServiceImplTest.java
+++ b/src/test/java/manage/store/service/money/sales/SalesSummaryServiceImplTest.java
@@ -3,6 +3,8 @@ package manage.store.service.money.sales;
 import manage.store.consts.Tags;
 import manage.store.dto.money.sales.month.service.*;
 import manage.store.exception.common.InvalidParameterException;
+import manage.store.model.common.value.RegistDate;
+import manage.store.model.common.value.WeekNumber;
 import manage.store.model.common.value.YearMonth;
 import manage.store.model.money.sales.value.Money;
 import manage.store.testUtils.money.MonthlySalesUtils;
@@ -16,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -28,26 +31,143 @@ class SalesSummaryServiceImplTest {
 
 
     @Test
-    @DisplayName("getMonthSalesSummary 성공 - 일별 매출이 존재하는 경우")
-    void getMonthSalesSummary_success() {
+    @DisplayName("getMonthSalesSummary 성공 - 모든 일별 매출이 존재하는 경우")
+    void getMonthSalesSummary_success_fullSales() {
         // Given
         // 파라미터
         final YearMonth yearMonth = MonthlySalesUtils.YEAR_MONTH;
-        final List<BasicDailySales> dummySales = MonthlySalesUtils.BASIC_DAILY_SALES_2023_05;
+        final List<BasicDailySales> dummySales = MonthlySalesUtils.BASIC_DAILY_SALES_2023_05();
         final String branchCd = dummySales.get(0).getBranchCd();
 
         final GetMonthlySalesSummaryParam param = new GetMonthlySalesSummaryParam(branchCd, yearMonth, dummySales);
 
         // 예상 결과
         // 일별 통계
-        final List<SalesDailySummary> expectedDailySummary = MonthlySalesUtils.EXPECTED_DAILY_SUMMARY;
+        final List<SalesDailySummary> expectedDailySummary = MonthlySalesUtils.EXPECTED_DAILY_SUMMARY();
 
         // 주별 통계
-        final List<SalesWeeklySummary> expectedWeeklySummaries = MonthlySalesUtils.EXPECTED_WEEKLY_SUMMARY;
+        final List<SalesWeeklySummary> expectedWeeklySummaries = MonthlySalesUtils.EXPECTED_WEEKLY_SUMMARY();
 
         // 월 총 매출 통게
-        final Money expectedMonthTotalCard = MonthlySalesUtils.MONTH_TOTAL_CARD;
-        final Money expectedMonthTotalCash = MonthlySalesUtils.MONTH_TOTAL_CASH;
+        final Money expectedMonthTotalCard = MonthlySalesUtils.MONTH_TOTAL_CARD();
+        final Money expectedMonthTotalCash = MonthlySalesUtils.MONTH_TOTAL_CASH();
+        final Money expectedMonthTotalSales = expectedMonthTotalCard.add(expectedMonthTotalCash);
+
+        // When
+        GetMonthlySalesSummaryRslt result = salesSummaryService.getMonthSalesSummary(param);
+
+        // Then
+        // 기본
+        assertNotNull(result);
+        assertNotNull(result.salesDailySummary());
+        assertNotNull(result.salesWeeklySummary());
+        Assertions.assertThat(result.branchCd()).isEqualTo(branchCd);
+        Assertions.assertThat(result.yearMonth()).isEqualTo(yearMonth);
+
+        // 일별 통계
+        Assertions.assertThat(result.salesDailySummary().size()).isEqualTo(param.monthDailySales().size());
+        for (int i = 0; i < result.salesDailySummary().size(); i++) {
+            SalesDailySummary actual = result.salesDailySummary().get(i);
+            SalesDailySummary expected = expectedDailySummary.get(i);
+
+            Assertions.assertThat(actual.getBranchCd()).isEqualTo(expected.getBranchCd());
+            Assertions.assertThat(actual.getRegistDate()).isEqualTo(expected.getRegistDate());
+            Assertions.assertThat(actual.getWeeklyTotalSales()).isEqualTo(expected.getWeeklyTotalSales());
+            Assertions.assertThat(actual.getMonthTotalSales()).isEqualTo(expected.getMonthTotalSales());
+        }
+
+        // 주별 통계
+        Assertions.assertThat(result.salesWeeklySummary().size()).isEqualTo(5);
+        for (int i = 0; i < result.salesWeeklySummary().size(); i++) {
+            SalesWeeklySummary actual = result.salesWeeklySummary().get(i);
+            SalesWeeklySummary expected = expectedWeeklySummaries.get(i);
+
+            Assertions.assertThat(actual.getBranchCd()).isEqualTo(expected.getBranchCd());
+            Assertions.assertThat(actual.getYearMonth()).isEqualTo(expected.getYearMonth());
+            Assertions.assertThat(actual.getWeekNumber()).isEqualTo(expected.getWeekNumber());
+            Assertions.assertThat(actual.getSalesAvg()).isEqualTo(expected.getSalesAvg());
+            Assertions.assertThat(actual.getExpectedTotalSales()).isEqualTo(expected.getExpectedTotalSales());
+        }
+
+        // 월 총 매출 통계
+        Assertions.assertThat(result.monthTotalCash()).isEqualTo(expectedMonthTotalCash);
+        Assertions.assertThat(result.monthTotalCard()).isEqualTo(expectedMonthTotalCard);
+        Assertions.assertThat(result.monthTotalSales()).isEqualTo(expectedMonthTotalSales);
+    }
+
+    @Test
+    @DisplayName("getMonthSalesSummary 성공 - 일부 일별 매출이 존재하는 경우")
+    void getMonthSalesSummary_success_notFullSales() {
+        // Given
+        // 파라미터
+        final int notEmptySalesCnt = 10;
+        final String branchCd = MonthlySalesUtils.BRANCH_CD;
+        final YearMonth yearMonth = MonthlySalesUtils.YEAR_MONTH;
+        List<BasicDailySales> dummySales = IntStream.range(0, MonthlySalesUtils.BASIC_DAILY_SALES_2023_05().size())
+                .mapToObj(idx -> {
+                    BasicDailySales sales = MonthlySalesUtils.BASIC_DAILY_SALES_2023_05().get(idx);
+
+                    if (idx <= 9) {
+                        return sales;
+                    } else {
+                        return sales.setCardSales(new Money(0L))
+                                .setCashSales(new Money(0L))
+                                .setTotalSales(new Money(0L))
+                                .setCardPercentage(0);
+                    }
+                })
+                .toList();
+
+        final GetMonthlySalesSummaryParam param = new GetMonthlySalesSummaryParam(branchCd, yearMonth, dummySales);
+
+        // 예상 결과
+        // 일별 통계
+        final List<SalesDailySummary> dailySummary = MonthlySalesUtils.EXPECTED_DAILY_SUMMARY();
+        dailySummary.set(10, new SalesDailySummary(MonthlySalesUtils.BRANCH_CD, new RegistDate("2023-05-11"), new Money(54L), new Money(110L)));
+        dailySummary.set(11, new SalesDailySummary(MonthlySalesUtils.BRANCH_CD, new RegistDate("2023-05-12"), new Money(54L), new Money(110L)));
+        dailySummary.set(12, new SalesDailySummary(MonthlySalesUtils.BRANCH_CD, new RegistDate("2023-05-13"), new Money(54L), new Money(110L)));
+        dailySummary.set(13, new SalesDailySummary(MonthlySalesUtils.BRANCH_CD, new RegistDate("2023-05-14"), new Money(54L), new Money(110L)));
+        final List<SalesDailySummary> expectedDailySummary = IntStream.range(0, dailySummary.size())
+                        .mapToObj(idx -> {
+                            SalesDailySummary currentSales = dailySummary.get(idx);
+
+                            if (idx < 14) {
+                                return currentSales;
+                            } else {
+                                return currentSales
+                                        .setWeeklyTotalSales(new Money(0L))
+                                        .setMonthTotalSales(new Money(110L));
+                            }
+                        })
+                        .toList();
+
+        // 주별 통계
+        final List<SalesWeeklySummary> expectedWeeklySummaries = new ArrayList<>(){{
+            add(new SalesWeeklySummary.Builder(MonthlySalesUtils.BRANCH_CD, MonthlySalesUtils.YEAR_MONTH, new WeekNumber(1))
+                    .salesAvg(new Money(8L))
+                    .expectedTotalSales(new Money(56L))
+                    .build());
+            add(new SalesWeeklySummary.Builder(MonthlySalesUtils.BRANCH_CD, MonthlySalesUtils.YEAR_MONTH, new WeekNumber(2))
+                    .salesAvg(new Money(7L))
+                    .expectedTotalSales(new Money(54L))
+                    .build());
+            add(new SalesWeeklySummary.Builder(MonthlySalesUtils.BRANCH_CD, MonthlySalesUtils.YEAR_MONTH, new WeekNumber(3))
+                    .salesAvg(new Money(0L))
+                    .expectedTotalSales(new Money(0L))
+                    .build());
+            add(new SalesWeeklySummary.Builder(MonthlySalesUtils.BRANCH_CD, MonthlySalesUtils.YEAR_MONTH, new WeekNumber(4))
+                    .salesAvg(new Money(0L))
+                    .expectedTotalSales(new Money(0L))
+                    .build());
+            add(new SalesWeeklySummary.Builder(MonthlySalesUtils.BRANCH_CD, MonthlySalesUtils.YEAR_MONTH, new WeekNumber(5))
+                    .salesAvg(new Money(0L))
+                    .expectedTotalSales(new Money(0L))
+                    .build());
+        }};
+
+        // 월 총 매출 통게
+        final Money expectedMonthTotalCard = new Money(55L);
+        final Money expectedMonthTotalCash = new Money(55L);
         final Money expectedMonthTotalSales = expectedMonthTotalCard.add(expectedMonthTotalCash);
 
         // When
@@ -95,7 +215,7 @@ class SalesSummaryServiceImplTest {
     @Test
     @DisplayName("getMonthSalesSummary 성공 - 일별 매출이 없는 경우")
     void getMonthSalesSummary_noDailySales() {
-// Given
+        // Given
         // 파라미터
         final YearMonth yearMonth = new YearMonth(2023, 5);
         final List<BasicDailySales> dummySales = new ArrayList<>();

--- a/src/test/java/manage/store/testUtils/money/MonthlySalesUtils.java
+++ b/src/test/java/manage/store/testUtils/money/MonthlySalesUtils.java
@@ -25,15 +25,49 @@ public class MonthlySalesUtils {
     /**
      * 2023년 5월의 일별 매출 데이터 리스트
      * 일별 카드 / 현금 매출은 일자와 동일
+     * Ex) 1일 -> card, cash: 1
+     */
+    public static List<StoreSales> STORE_SALES_2023_05() {
+        List<StoreSales> storeSalesList = new ArrayList<>();
+
+        LocalDate startDate = LocalDate.of(YEAR_MONTH.getYear(), YEAR_MONTH.getMonth(), 1);
+        LocalDate endDate = LocalDate.of(YEAR_MONTH.getYear(), YEAR_MONTH.getMonth(), 31);
+        LocalDate currentDate = startDate;
+
+        while (!currentDate.isAfter(endDate)) {
+            long dayValue = currentDate.getDayOfMonth();
+
+            Money card = new Money(dayValue);
+            Money cash = new Money(dayValue);
+
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+            String yyyyMMdd = currentDate.format(formatter);
+
+            RegistDate regDate = new RegistDate(yyyyMMdd);
+
+            StoreSales storeSales = new StoreSales();
+            storeSales.setBranchCd(BRANCH_CD);
+            storeSales.setRegistDate(regDate);
+            storeSales.setCardSales(card);
+            storeSales.setCashSales(cash);
+            storeSales.setComment("comment_" + card.value());
+            storeSales.setCreatedBy(new UserId("userId"));
+            storeSales.setLastUpdatedBy(new UserId("userId"));
+            storeSalesList.add(storeSales);
+
+            currentDate = currentDate.plusDays(1);
+        }
+
+        return Collections.unmodifiableList(storeSalesList);
+    }
+
+    /**
+     * 2023년 5월의 일별 매출 데이터 리스트
+     * 일별 카드 / 현금 매출은 일자와 동일
      * Ex) 1일 -> card, cash: 1, total: 2, cardPercentage: 50
      */
-    public static final List<BasicDailySales> BASIC_DAILY_SALES_2023_05;
-
-    public static final List<StoreSales> STORE_SALES_2023_05;
-
-    static {
+    public static List<BasicDailySales> BASIC_DAILY_SALES_2023_05() {
         List<BasicDailySales> salesList = new ArrayList<>();
-        List<StoreSales> storeSalesList = new ArrayList<>();
 
         LocalDate startDate = LocalDate.of(YEAR_MONTH.getYear(), YEAR_MONTH.getMonth(), 1);
         LocalDate endDate = LocalDate.of(YEAR_MONTH.getYear(), YEAR_MONTH.getMonth(), 31);
@@ -62,92 +96,88 @@ public class MonthlySalesUtils {
             );
             salesList.add(dailySale);
 
-            StoreSales storeSales = new StoreSales();
-            storeSales.setBranchCd(BRANCH_CD);
-            storeSales.setRegistDate(regDate);
-            storeSales.setCardSales(card);
-            storeSales.setCashSales(cash);
-            storeSales.setComment("comment_" + card.value());
-            storeSales.setCreatedBy(new UserId("userId"));
-            storeSales.setLastUpdatedBy(new UserId("userId"));
-            storeSalesList.add(storeSales);
-
             currentDate = currentDate.plusDays(1);
         }
 
-        BASIC_DAILY_SALES_2023_05 = Collections.unmodifiableList(salesList);
-
-        STORE_SALES_2023_05 = Collections.unmodifiableList(storeSalesList);
+        return Collections.unmodifiableList(salesList);
     }
 
-    public static final List<SalesDailySummary> EXPECTED_DAILY_SUMMARY = List.of(
+    public static List<SalesDailySummary> EXPECTED_DAILY_SUMMARY() {
+        return new ArrayList<>(){{
             // --- 1주차
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-01"), new Money(2L), new Money(2L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-02"), new Money(6L), new Money(6L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-03"), new Money(12L), new Money(12L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-04"), new Money(20L), new Money(20L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-05"), new Money(30L), new Money(30L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-06"), new Money(42L), new Money(42L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-07"), new Money(56L), new Money(56L)),
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-01"), new Money(2L), new Money(2L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-02"), new Money(6L), new Money(6L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-03"), new Money(12L), new Money(12L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-04"), new Money(20L), new Money(20L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-05"), new Money(30L), new Money(30L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-06"), new Money(42L), new Money(42L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-07"), new Money(56L), new Money(56L)));
 
             // --- 2주차
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-08"), new Money(16L), new Money(72L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-09"), new Money(34L), new Money(90L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-10"), new Money(54L), new Money(110L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-11"), new Money(76L), new Money(132L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-12"), new Money(100L), new Money(156L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-13"), new Money(126L), new Money(182L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-14"), new Money(154L), new Money(210L)),
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-08"), new Money(16L), new Money(72L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-09"), new Money(34L), new Money(90L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-10"), new Money(54L), new Money(110L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-11"), new Money(76L), new Money(132L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-12"), new Money(100L), new Money(156L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-13"), new Money(126L), new Money(182L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-14"), new Money(154L), new Money(210L)));
 
             // --- 3주차
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-15"), new Money(30L), new Money(240L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-16"), new Money(62L), new Money(272L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-17"), new Money(96L), new Money(306L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-18"), new Money(132L), new Money(342L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-19"), new Money(170L), new Money(380L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-20"), new Money(210L), new Money(420L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-21"), new Money(252L), new Money(462L)),
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-15"), new Money(30L), new Money(240L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-16"), new Money(62L), new Money(272L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-17"), new Money(96L), new Money(306L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-18"), new Money(132L), new Money(342L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-19"), new Money(170L), new Money(380L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-20"), new Money(210L), new Money(420L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-21"), new Money(252L), new Money(462L)));
 
             // --- 4주차
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-22"), new Money(44L), new Money(506L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-23"), new Money(90L), new Money(552L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-24"), new Money(138L), new Money(600L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-25"), new Money(188L), new Money(650L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-26"), new Money(240L), new Money(702L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-27"), new Money(294L), new Money(756L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-28"), new Money(350L), new Money(812L)),
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-22"), new Money(44L), new Money(506L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-23"), new Money(90L), new Money(552L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-24"), new Money(138L), new Money(600L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-25"), new Money(188L), new Money(650L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-26"), new Money(240L), new Money(702L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-27"), new Money(294L), new Money(756L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-28"), new Money(350L), new Money(812L)));
 
             // --- 5주차
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-29"), new Money(58L), new Money(870L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-30"), new Money(118L), new Money(930L)),
-            new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-31"), new Money(180L), new Money(992L))
-    );
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-29"), new Money(58L), new Money(870L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-30"), new Money(118L), new Money(930L)));
+            add(new SalesDailySummary(BRANCH_CD, new RegistDate("2023-05-31"), new Money(180L), new Money(992L)));
+        }};
+    }
 
-    public static final List<SalesWeeklySummary> EXPECTED_WEEKLY_SUMMARY = new ArrayList<>(){{
-        add(new SalesWeeklySummary.Builder(BRANCH_CD, YEAR_MONTH, new WeekNumber(1))
-                .salesAvg(new Money(8L))
-                .expectedTotalSales(new Money(56L))
-                .build());
-        add(new SalesWeeklySummary.Builder(BRANCH_CD, YEAR_MONTH, new WeekNumber(2))
-                .salesAvg(new Money(22L))
-                .expectedTotalSales(new Money(154L))
-                .build());
-        add(new SalesWeeklySummary.Builder(BRANCH_CD, YEAR_MONTH, new WeekNumber(3))
-                .salesAvg(new Money(36L))
-                .expectedTotalSales(new Money(252L))
-                .build());
-        add(new SalesWeeklySummary.Builder(BRANCH_CD, YEAR_MONTH, new WeekNumber(4))
-                .salesAvg(new Money(50L))
-                .expectedTotalSales(new Money(350L))
-                .build());
-        add(new SalesWeeklySummary.Builder(BRANCH_CD, YEAR_MONTH, new WeekNumber(5))
-                .salesAvg(new Money(60L))
-                .expectedTotalSales(new Money(420L))
-                .build());
-    }};
+    public static List<SalesWeeklySummary> EXPECTED_WEEKLY_SUMMARY() {
+        return new ArrayList<>(){{
+            add(new SalesWeeklySummary.Builder(BRANCH_CD, YEAR_MONTH, new WeekNumber(1))
+                    .salesAvg(new Money(8L))
+                    .expectedTotalSales(new Money(56L))
+                    .build());
+            add(new SalesWeeklySummary.Builder(BRANCH_CD, YEAR_MONTH, new WeekNumber(2))
+                    .salesAvg(new Money(22L))
+                    .expectedTotalSales(new Money(154L))
+                    .build());
+            add(new SalesWeeklySummary.Builder(BRANCH_CD, YEAR_MONTH, new WeekNumber(3))
+                    .salesAvg(new Money(36L))
+                    .expectedTotalSales(new Money(252L))
+                    .build());
+            add(new SalesWeeklySummary.Builder(BRANCH_CD, YEAR_MONTH, new WeekNumber(4))
+                    .salesAvg(new Money(50L))
+                    .expectedTotalSales(new Money(350L))
+                    .build());
+            add(new SalesWeeklySummary.Builder(BRANCH_CD, YEAR_MONTH, new WeekNumber(5))
+                    .salesAvg(new Money(60L))
+                    .expectedTotalSales(new Money(180L))
+                    .build());
+        }};
+    }
 
-    public static final Money MONTH_TOTAL_CARD = new Money(496L);
+    public static Money MONTH_TOTAL_CARD() {
+        return new Money(496L);
+    }
 
-    public static final Money MONTH_TOTAL_CASH = new Money(496L);
+    public static Money MONTH_TOTAL_CASH() {
+        return new Money(496L);
+    }
 
 }


### PR DESCRIPTION
- 매출 통계 로직에서 주간 예측 매출에 대한 로직 수정 (오늘이 포함된 주에서는 항상 예측 데이터가, 그 외 경우 실제 매출 데이터가 사용됨)